### PR TITLE
Fix export of Host in vsphere type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kubev2v/types",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kubev2v/types",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "^2.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubev2v/types",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Typescript interfaces and types for forklift-console-plugin",
   "license": "Apache-2.0",
   "private": false,

--- a/src/types/provider/vsphere/index.ts
+++ b/src/types/provider/vsphere/index.ts
@@ -1,7 +1,7 @@
 // @index(['./*'], f => `export * from '${f.path}';`)
 export * from './DataStore';
 export * from './Host';
-export * from './host';
+export * from './host/index';
 export * from './model';
 export * from './Network';
 export * from './Provider';


### PR DESCRIPTION
Issue:
Ass reported by @jschuler in the file `src/types/provider/vsphere/index.ts` host is not a module.

Fix:
Make the export specific to file

