### PR TITLE
feat(hyperv): add Hyper-V provider inventory types

### DIFF
--- a/src/types/ProviderVM.ts
+++ b/src/types/ProviderVM.ts
@@ -1,8 +1,14 @@
-/** Unified file containing typed provider secrets */
+/** Unified file containing typed provider virtual machines */
 
-import { OpenshiftVM, OpenstackVM, OvaVM, OVirtVM, VSphereVM } from './provider';
+import { HypervVM, OpenshiftVM, OpenstackVM, OvaVM, OVirtVM, VSphereVM } from './provider';
 
 /**
  * General provider virtual machine inventory
  */
-export type ProviderVirtualMachine = OpenshiftVM | OVirtVM | VSphereVM | OpenstackVM | OvaVM;
+export type ProviderVirtualMachine =
+  | OpenshiftVM
+  | OVirtVM
+  | VSphereVM
+  | OpenstackVM
+  | OvaVM
+  | HypervVM;

--- a/src/types/ProvidersInventoryList.ts
+++ b/src/types/ProvidersInventoryList.ts
@@ -1,4 +1,5 @@
 import {
+  HypervProvider,
   OpenshiftProvider,
   OpenstackProvider,
   OvaProvider,
@@ -15,4 +16,5 @@ export interface ProvidersInventoryList {
   ovirt?: OVirtProvider[] | null;
   vsphere?: VSphereProvider[] | null;
   ova?: OvaProvider[] | null;
+  hyperv?: HypervProvider[] | null;
 }

--- a/src/types/provider/hyperv/Network.ts
+++ b/src/types/provider/hyperv/Network.ts
@@ -1,0 +1,6 @@
+import { TypedHypervResource } from './TypedResource';
+
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/hyperv/network.go
+export interface HypervNetwork extends TypedHypervResource {
+  description?: string;
+}

--- a/src/types/provider/hyperv/Provider.ts
+++ b/src/types/provider/hyperv/Provider.ts
@@ -1,0 +1,23 @@
+import { V1beta1Provider } from '../../../generated';
+
+import { HypervResource } from './Resource';
+
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/hyperv/provider.go
+export interface HypervProvider extends HypervResource {
+  // Type
+  type: string;
+  // Object
+  object: V1beta1Provider;
+  // APIVersion
+  apiVersion: string;
+  // Product
+  product: string;
+  // VMCount
+  vmCount: number;
+  // NetworkCount
+  networkCount: number;
+  // DiskCount
+  diskCount: number;
+  // StorageCount
+  storageCount: number;
+}

--- a/src/types/provider/hyperv/Resource.ts
+++ b/src/types/provider/hyperv/Resource.ts
@@ -1,0 +1,15 @@
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/hyperv/resource.go
+export interface HypervResource {
+  // Object ID.
+  id: string;
+  // Variant
+  variant?: string;
+  // Path
+  path?: string;
+  // Revision
+  revision: number;
+  // Object name.
+  name: string;
+  // Self link.
+  selfLink: string;
+}

--- a/src/types/provider/hyperv/TreeNode.ts
+++ b/src/types/provider/hyperv/TreeNode.ts
@@ -1,0 +1,7 @@
+import { TreeNode } from '../base/TreeNode';
+
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/model/hyperv/tree.go
+export interface HypervTreeNode extends TreeNode {
+  kind: '' | 'Datacenter' | 'Folder' | 'VM' | 'Cluster' | 'Host' | 'Network' | 'Datastore';
+  children: HypervTreeNode[] | null;
+}

--- a/src/types/provider/hyperv/TypedResource.ts
+++ b/src/types/provider/hyperv/TypedResource.ts
@@ -1,0 +1,6 @@
+import { HypervResource } from './Resource';
+
+export interface TypedHypervResource extends HypervResource {
+  // prop added by the UI to implement narrowing (discriminated union)
+  providerType: 'hyperv';
+}

--- a/src/types/provider/hyperv/VM.ts
+++ b/src/types/provider/hyperv/VM.ts
@@ -1,0 +1,55 @@
+import { Concern } from '../base/model';
+
+import { HypervNetwork } from './Network';
+import { TypedHypervResource } from './TypedResource';
+
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/hyperv/vm.go
+export interface HypervVM extends TypedHypervResource {
+  path: string;
+  revisionValidated: number;
+  policyVersion: number;
+  uuid: string;
+  firmware: string;
+  cpuAffinity: number[];
+  cpuHotAddEnabled: boolean;
+  cpuHotRemoveEnabled: boolean;
+  memoryHotAddEnabled: boolean;
+  faultToleranceEnabled: boolean;
+  cpuCount: number;
+  coresPerSocket: number;
+  memoryMB: number;
+  balloonedMemory: number;
+  ipAddress: string;
+  numaNodeAffinity: string[];
+  storageUsed: number;
+  changeTrackingEnabled: boolean;
+  devices: HypervDevice[];
+  nics: HypervNic[];
+  disks: HypervDisk[];
+  networks: HypervNetwork[];
+  concerns: Concern[];
+}
+
+export interface HypervDevice {
+  kind: string;
+}
+
+export interface HypervNicConf {
+  key: string;
+  value: string;
+}
+
+export interface HypervNic {
+  name: string;
+  mac: string;
+  config: HypervNicConf[];
+}
+
+export interface HypervDisk {
+  capacity: string;
+  capacityAllocationUnits: string;
+  diskId: string;
+  fileRef: string;
+  format: string;
+  populatedSize: string;
+}

--- a/src/types/provider/hyperv/index.ts
+++ b/src/types/provider/hyperv/index.ts
@@ -1,0 +1,8 @@
+// @index(['./*'], f => `export * from '${f.path}';`)
+export * from './Network';
+export * from './Provider';
+export * from './Resource';
+export * from './TreeNode';
+export * from './TypedResource';
+export * from './VM';
+// @endindex

--- a/src/types/provider/index.ts
+++ b/src/types/provider/index.ts
@@ -1,5 +1,6 @@
 // @index('./*', f => `export * from '${f.path}';`)
 export * from './base';
+export * from './hyperv';
 export * from './openshift';
 export * from './openstack';
 export * from './ova';


### PR DESCRIPTION
## Summary
Add inventory types for the Hyper-V provider to support Hyper-V VM migrations.

## Changes

### New Files (`src/types/provider/hyperv/`)
- **Network.ts**: Network resource type
- **Provider.ts**: Hyper-V provider definition  
- **Resource.ts**: Base resource interface
- **TreeNode.ts**: Tree node structure
- **TypedResource.ts**: Typed resource interface
- **VM.ts**: Virtual machine type with disk, NIC, and concern details
- **index.ts**: Module exports

### Updated Files
- **ProviderVM.ts**: Add HypervVM to union type
- **ProvidersInventoryList.ts**: Add Hyper-V provider list
- **provider/index.ts**: Export hyperv module