### PR TITLE
chore: bump version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forklift-ui/types",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Typescript interfaces and types for forklift-console-plugin",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
## Summary
Bump version to 1.0.6 to publish the HyperV provider fixes.

## Changes
- Version bump from 1.0.5 to 1.0.6

## Fixes Included (already in main)
This release includes the HyperV provider inventory type fixes from PR #20 and #21:
- `HypervProvider` now extends `OpenshiftResource` (has `uid`, `version`, `namespace`)
- `HypervProvider` added to `ProviderInventory` union type

## Why
The current npm package v1.0.5 was published before PR #20 and #21 were merged, so it's missing these fixes. This version bump will trigger a new npm release with the correct types.