### PR TITLE
fix(hyperv): HypervProvider extends OpenshiftResource and add to ProviderInventory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forklift-ui/types",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Typescript interfaces and types for forklift-console-plugin",
   "license": "Apache-2.0",
   "private": false,

--- a/src/types/ProviderInventory.ts
+++ b/src/types/ProviderInventory.ts
@@ -1,4 +1,5 @@
 import {
+  HypervProvider,
   OpenshiftProvider,
   OpenstackProvider,
   OvaProvider,
@@ -14,4 +15,5 @@ export type ProviderInventory =
   | OpenstackProvider
   | OVirtProvider
   | VSphereProvider
-  | OvaProvider;
+  | OvaProvider
+  | HypervProvider;

--- a/src/types/provider/hyperv/Provider.ts
+++ b/src/types/provider/hyperv/Provider.ts
@@ -1,9 +1,9 @@
 import { V1beta1Provider } from '../../../generated/forklift/models';
 
-import { HypervResource } from './Resource';
+import { OpenshiftResource } from '../openshift/Resource';
 
 // https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/hyperv/provider.go
-export interface HypervProvider extends HypervResource {
+export interface HypervProvider extends OpenshiftResource {
   // Type
   type: string;
   // Object


### PR DESCRIPTION
## Summary
Fix HypervProvider type inheritance and add it to ProviderInventory union.

## Changes
- Change `HypervProvider` to extend `OpenshiftResource` instead of `HypervResource`
- Add `HypervProvider` to `ProviderInventory` union type
- Bump version to 1.0.7

## Why This Is Needed
The current v1.0.6 has two issues:

1. **Wrong inheritance**: `HypervProvider extends HypervResource` means it has `id` instead of `uid`, `version`, `namespace` that other providers have (from `OpenshiftResource`)
2. **Missing from ProviderInventory**: `HypervProvider` is not included in the `ProviderInventory` union, causing type errors when iterating over providers

## Testing
- Build passes
- Types correctly export `HypervProvider` with `uid`, `version`, `namespace` from `OpenshiftResource`
- `ProviderInventory` now includes `HypervProvider`