### PR TITLE
chore: add post-generation timestamp fix script

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -14,8 +14,9 @@ This document provides comprehensive instructions for maintaining and updating t
 4. [Resolving Export Conflicts](#resolving-export-conflicts)
 5. [Local Testing](#local-testing)
 6. [Publishing](#publishing)
-7. [Troubleshooting](#troubleshooting)
-8. [Version Tracking](#version-tracking)
+7. [Post-Generation Fixes](#post-generation-fixes)
+8. [Troubleshooting](#troubleshooting)
+9. [Version Tracking](#version-tracking)
 
 ---
 
@@ -385,6 +386,25 @@ Track which upstream versions are currently included. **Update this table after 
 | `./scripts/update-kubevirt.sh [version]` | Update KubeVirt VM types |
 | `./scripts/update-cdi.sh [version]` | Update CDI DataVolume types |
 | `./scripts/check-conflicts.sh` | Detect export conflicts between KubeVirt and CDI |
+| `./scripts/fix-timestamp-types.sh` | Fix ObjectMeta timestamp types (Date → string) |
 
 All scripts accept an optional version argument (branch name or tag). Default is `main` or `master`.
 
+
+---
+
+## Post-Generation Fixes
+
+After running any update script, run the post-generation fix script:
+
+```bash
+npm run fix:timestamps
+```
+
+### ObjectMeta Timestamp Types
+
+The `openapi-generator` maps OpenAPI `date-time` format fields to TypeScript `Date`. However, the Kubernetes API returns ISO 8601 strings for timestamp fields, and `@openshift-console/dynamic-plugin-sdk` types `creationTimestamp` and `deletionTimestamp` as `string`.
+
+The `fix:timestamps` script patches all generated `ObjectMeta` types (Kubernetes, KubeVirt, CDI) to use `string` instead of `Date` for these fields, maintaining compatibility with the Console SDK.
+
+This fix was introduced after the Kubernetes v1.36.0 update exposed the incompatibility (see PR #26).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "update:kubernetes": "./scripts/update-kubernetes.sh",
     "update:kubevirt": "./scripts/update-kubevirt.sh",
     "update:cdi": "./scripts/update-cdi.sh",
-    "check:conflicts": "./scripts/check-conflicts.sh"
+    "check:conflicts": "./scripts/check-conflicts.sh",
+    "fix:timestamps": "./scripts/fix-timestamp-types.sh"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.13.4",

--- a/scripts/fix-timestamp-types.sh
+++ b/scripts/fix-timestamp-types.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Fix ObjectMeta timestamp types after code generation
+#
+# The openapi-generator maps OpenAPI `date-time` format to TypeScript `Date`,
+# but the Kubernetes API returns ISO 8601 strings and the OpenShift Console SDK
+# types creationTimestamp/deletionTimestamp as `string`.
+#
+# This script patches all generated ObjectMeta types to use `string` instead of
+# `Date` for these fields, maintaining compatibility with the Console SDK.
+#
+# Usage: ./scripts/fix-timestamp-types.sh
+#
+# Safe to run multiple times (idempotent).
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+GENERATED_DIR="$PROJECT_ROOT/src/generated"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Fixing ObjectMeta Timestamp Types${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+FIXED_COUNT=0
+
+# Find all files with ObjectMeta in the name that contain Date-typed timestamps
+while IFS= read -r -d '' file; do
+  relative_path="${file#$PROJECT_ROOT/}"
+  changed=false
+
+  # Fix type declarations: creationTimestamp?: Date -> creationTimestamp?: string
+  if grep -q 'creationTimestamp?: Date;' "$file"; then
+    sed -i '' 's/creationTimestamp?: Date;/creationTimestamp?: string;/g' "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: creationTimestamp type → string${NC}"
+    changed=true
+  fi
+
+  if grep -q 'deletionTimestamp?: Date;' "$file"; then
+    sed -i '' 's/deletionTimestamp?: Date;/deletionTimestamp?: string;/g' "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: deletionTimestamp type → string${NC}"
+    changed=true
+  fi
+
+  # Fix FromJSON: (new Date(json['creationTimestamp'])) -> json['creationTimestamp']
+  if grep -q "(new Date(json\['creationTimestamp'\]))" "$file"; then
+    sed -i '' "s/(new Date(json\['creationTimestamp'\]))/json['creationTimestamp']/g" "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: creationTimestamp FromJSON → passthrough${NC}"
+    changed=true
+  fi
+
+  if grep -q "(new Date(json\['deletionTimestamp'\]))" "$file"; then
+    sed -i '' "s/(new Date(json\['deletionTimestamp'\]))/json['deletionTimestamp']/g" "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: deletionTimestamp FromJSON → passthrough${NC}"
+    changed=true
+  fi
+
+  # Fix ToJSON: ((value['creationTimestamp']).toISOString()) -> value['creationTimestamp']
+  if grep -q "((value\['creationTimestamp'\])\.toISOString())" "$file"; then
+    sed -i '' "s/((value\['creationTimestamp'\])\.toISOString())/value['creationTimestamp']/g" "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: creationTimestamp ToJSON → passthrough${NC}"
+    changed=true
+  fi
+
+  if grep -q "((value\['deletionTimestamp'\])\.toISOString())" "$file"; then
+    sed -i '' "s/((value\['deletionTimestamp'\])\.toISOString())/value['deletionTimestamp']/g" "$file"
+    echo -e "${GREEN}  ✓ ${relative_path}: deletionTimestamp ToJSON → passthrough${NC}"
+    changed=true
+  fi
+
+  if [ "$changed" = true ]; then
+    FIXED_COUNT=$((FIXED_COUNT + 1))
+  fi
+done < <(find "$GENERATED_DIR" -type f -name "*ObjectMeta*" -print0)
+
+echo ""
+if [ "$FIXED_COUNT" -gt 0 ]; then
+  echo -e "${GREEN}========================================${NC}"
+  echo -e "${GREEN}Fixed timestamp types in ${FIXED_COUNT} file(s)${NC}"
+  echo -e "${GREEN}========================================${NC}"
+else
+  echo -e "${YELLOW}========================================${NC}"
+  echo -e "${YELLOW}No fixes needed — timestamps already use string${NC}"
+  echo -e "${YELLOW}========================================${NC}"
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/fix-timestamp-types.sh` to automatically fix the `Date` → `string` incompatibility in ObjectMeta timestamp fields (`creationTimestamp`, `deletionTimestamp`) after running `openapi-generator`
- Adds `npm run fix:timestamps` convenience script
- Documents the fix in MAINTENANCE.md under a new "Post-Generation Fixes" section

## Context

The `openapi-generator` maps OpenAPI `date-time` format to TypeScript `Date`, but the Kubernetes API returns ISO 8601 strings and `@openshift-console/dynamic-plugin-sdk` types these fields as `string`. This was manually fixed in PR #26 after the Kubernetes v1.36.0 update. This script automates the fix for future regeneration runs.

The script is idempotent — safe to run multiple times without side effects.

## Test plan

- [x] Script runs successfully on already-patched files (no-op)
- [ ] Verify script works after a fresh `npm run update:kubernetes` regeneration
- [ ] `npm run build` passes after running the fix


Made with [Cursor](https://cursor.com)