### PR TITLE
feat: add guest OS fields to vSphere and oVirt VM types

### DIFF
--- a/src/types/provider/ovirt/VM.ts
+++ b/src/types/provider/ovirt/VM.ts
@@ -12,6 +12,12 @@ export interface OVirtVM extends TypedOVirtResource {
   status: string;
   // Host              string           `json:"host"`
   host: string;
+  // GuestName                   string `json:"guestName"`
+  guestName: string;
+  // OSType                      string `json:"osType"`
+  osType: string;
+  // Guest                       Guest  `json:"guest"`
+  guest: OVirtGuest;
   // RevisionValidated int64            `json:"revisionValidated"`
   revisionValidated: number;
   // NICs              []OVirtNIC           `json:"nics"`
@@ -20,4 +26,11 @@ export interface OVirtVM extends TypedOVirtResource {
   diskAttachments: OVirtDiskAttachment[];
   // Concerns          []Concern        `json:"concerns"`
   concerns: Concern[];
+}
+
+export interface OVirtGuest {
+  // Distribution string `json:"distribution"`
+  distribution: string;
+  // FullVersion  string `json:"fullVersion"`
+  fullVersion: string;
 }

--- a/src/types/provider/vsphere/VM.ts
+++ b/src/types/provider/vsphere/VM.ts
@@ -14,6 +14,12 @@ export interface VSphereVM extends TypedVSphereResource {
   powerState: string;
   // Host              string          `json:"host"`
   host: string;
+  // GuestName                string `json:"guestName"`
+  guestName: string;
+  // GuestNameFromVmwareTools string `json:"guestNameFromVmwareTools"`
+  guestNameFromVmwareTools: string;
+  // GuestID                  string `json:"guestId"`
+  guestId: string;
   // Networks          []model.Ref     `json:"networks"`
   networks: Ref[];
   // Disks             []model.Disk    `json:"disks"`


### PR DESCRIPTION
Add guest OS fields to VSphereVM and OVirtVM interfaces that are returned by the Forklift inventory API but were missing from the TypeScript types.

  **vSphere**

  Added guestName, guestNameFromVmwareTools, and guestId to VSphereVM, matching the REST API struct:

  - [pkg/controller/provider/web/vsphere/vm.go#L282-L285](https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/web/vsphere/vm.go#L282-L285)

  **oVirt**

  Added guestName, osType, and guest (new OVirtGuest interface with distribution and fullVersion) to OVirtVM, matching:

  - [pkg/controller/provider/web/ovirt/vm.go#L226](https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/web/ovirt/vm.go#L226) — guestName
  - [pkg/controller/provider/web/ovirt/vm.go#L254-L255](https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/web/ovirt/vm.go#L254-L255) — guest, osType
  - [pkg/controller/provider/model/ovirt/model.go#L247-L248](https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/model/ovirt/model.go#L247-L248) — Guest struct (distribution, fullVersion)

  **Motivation**

  These fields are needed by the console plugin to display a Guest OS column in VM tables (MTV-5503).